### PR TITLE
Fix for the "gogcom id" row

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,7 +176,7 @@ func main() {
 			dlcs += "\n"
 			outputFile.WriteString(dlcs)
 		}
-		outputFile.WriteString("||gogcom id    = \n|gogcom id side = \n|official site= ")
+		outputFile.WriteString("|gogcom id    = \n|gogcom id side = \n|official site= ")
 
 		if game[gameId].Data.Website != nil {
 			outputFile.WriteString(*game[gameId].Data.Website)


### PR DESCRIPTION
Seemed easy enough for me to submit a PR for in time for 0.0.71. The problem was that the row was starting with two vertical lines instead of one, causing occasional problems with seemingly random things.